### PR TITLE
Implemented a lower-bound threshold for the calculations to activate LED Changed upper-bound threshold to be more tolerant for average BPM  Used same logic as upper-bound threshold, but changed frequency values to be less than a value so that slow heartrates raise alarms as well  Significantly slow average heart rates now raise alarms and causes the LED to turn on

### DIFF
--- a/freq
+++ b/freq
@@ -64,9 +64,13 @@ int main(void)
             filter_outliers_and_average(frequency_array, ARRAY_SIZE, &average_frequency);
 
             // Light up LD2 (PA5) if the average frequency is > threshold
-            if (average_frequency > 5.0f||average_frequency < 1.0f) // Adjust this threshold as needed
+            if (average_frequency > 6.0f) // Adjust this threshold as needed
             {
                 HAL_GPIO_WritePin(GPIOA, GPIO_PIN_5, GPIO_PIN_SET); // Turn on LD2
+            }
+            else if (average_frequency < 0.8f) // Adjust this threshold as needed
+            {
+            	HAL_GPIO_WritePin(GPIOA, GPIO_PIN_5, GPIO_PIN_SET); // Turn on LD2
             }
             else
             {
@@ -89,7 +93,7 @@ int main(void)
 static void MX_TIM2_Init(void)
 {
     htim2.Instance = TIM2;
-    htim2.Init.Prescaler = 89; // Prescaler for 1 MHz timer clock
+    htim2.Init.Prescaler = 89; // Prescaler for 1 MHz timer clock (principle 3)
     htim2.Init.CounterMode = TIM_COUNTERMODE_UP;
     htim2.Init.Period = 0xFFFFFFFF; // Max value for 32-bit counter
     htim2.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;


### PR DESCRIPTION
Implemented a lower-bound threshold for the calculations to activate LED
Changed upper-bound threshold to be more tolerant for average BPM

Used same logic as upper-bound threshold, but changed frequency values to be less than a value so that slow heartrates raise alarms as well

Significantly slow average heart rates now raise alarms and causes the LED to turn on